### PR TITLE
Aplicação dos logos no cabeçalho, rodape, login e cadastro

### DIFF
--- a/src/main/resources/templates/cadastroCliente.html
+++ b/src/main/resources/templates/cadastroCliente.html
@@ -7,6 +7,9 @@
 
 <main id="content" class="d-flex justify-content-center align-items-center" style="min-height: 100vh">
     <div style="width: 22rem">
+        <a href="/" class="d-flex align-items-center justify-content-center">
+            <img src="/assets/img/logos/2.png" alt="logo goservice" width="200" >
+        </a>
         <form method="post" th:action="@{/auth/cadastro}">
             <h1 class="h3 mb-3 fw-normal text-center">Cadastre-se | GoService</h1>
 

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -3,7 +3,7 @@
         <p class="col-md-4 mb-0 text-body-secondary">© 2023 Goservice, Inc</p>
 
         <a href="/" class="col-md-4 d-flex align-items-center justify-content-center mb-3 mb-md-0 me-md-auto link-body-emphasis text-decoration-none">
-          <svg class="bi me-2" width="40" height="32"><use xlink:href="#bootstrap"></use></svg>
+            <img src="/assets/img/logos/2.png" alt="logo goservice" width="100" >
         </a>
 
         <ul class="nav col-md-4 justify-content-end">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,7 +1,9 @@
 <header xmlns:th="http://www.thymeleaf.org" class="shadow p-3" th:fragment="header">
     <div class="container">
         <div class="d-flex gap-3 align-items-center justify-content-center justify-content-lg-start">
+
             <a href="/" class="d-flex align-items-center mb-2 mb-lg-0 text-dark text-decoration-none">
+                <img src="/assets/img/logos/2.png" alt="logo goservice" width="100" >
                 <h1>GoService</h1>
             </a>
 

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -7,7 +7,11 @@
 
 <main id="content" class="d-flex justify-content-center align-items-center" style="min-height: 100vh">
     <div style="width: 22rem">
+
         <form method="post" th:action="@{/auth/login}">
+            <a href="/" class="d-flex align-items-center justify-content-center">
+                <img src="/assets/img/logos/2.png" alt="logo goservice" width="200" >
+            </a>
             <h1 class="h3 mb-3 fw-normal text-center">Login | GoService</h1>
 
             <div th:if="${successMessage != null}" th:text="${successMessage}" class="alert alert-success" role="alert"></div>


### PR DESCRIPTION
adição da imagem 2 como logotipo no cabeçalho, rodapé e paginas de login e cadastro